### PR TITLE
Modify tests for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ proptest = "0.9.4"
 lazy_static = "1.3.0"
 bytes = "0.4"
 blake2b-rs = "0.1.4"
+sha3 = "0.9.1"
+digest = "0.9"
 
 [[bench]]
 name = "mmr_benchmark"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "solidity-mmr": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/solidity-mmr/-/solidity-mmr-1.0.0.tgz",
+      "integrity": "sha512-L/oOzLYkVCubFL5Emmm0gsDm13VjU4/+iJr5cngLUcgmtZJ42vpmg/+WwIvBXeURfUtPRoCrujVXRwHsx3UQAQ=="
+    }
+  }
+}

--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -269,6 +269,11 @@ impl<T: PartialEq + Debug + Clone, M: Merge<Item = T>> MerkleProof<T, M> {
     }
 
     pub fn verify(&self, root: T, leaves: Vec<(u64, T)>) -> Result<bool> {
+        println!("");
+        println!("root: {:?}", root);
+        println!("leaves len: {}", leaves.len());
+        println!("leaves: {:?}", leaves);
+        println!("");
         self.calculate_root(leaves)
             .map(|calculated_root| calculated_root == root)
     }
@@ -412,7 +417,10 @@ fn calculate_root<
     mmr_size: u64,
     proof_iter: I,
 ) -> Result<T> {
+    println!("mmr_size: {}", mmr_size);
     let peaks_hashes = calculate_peaks_hashes::<_, M, _>(leaves, mmr_size, proof_iter)?;
+    println!("peaks_hashes: {:#?}", peaks_hashes);
+
     bagging_peaks_hashes::<_, M>(peaks_hashes)
 }
 

--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -269,11 +269,6 @@ impl<T: PartialEq + Debug + Clone, M: Merge<Item = T>> MerkleProof<T, M> {
     }
 
     pub fn verify(&self, root: T, leaves: Vec<(u64, T)>) -> Result<bool> {
-        println!("");
-        println!("root: {:?}", root);
-        println!("leaves len: {}", leaves.len());
-        println!("leaves: {:?}", leaves);
-        println!("");
         self.calculate_root(leaves)
             .map(|calculated_root| calculated_root == root)
     }
@@ -417,10 +412,12 @@ fn calculate_root<
     mmr_size: u64,
     proof_iter: I,
 ) -> Result<T> {
-    println!("mmr_size: {}", mmr_size);
+    println!();
+    println!("Calling calculate_peaks_hashes...");
     let peaks_hashes = calculate_peaks_hashes::<_, M, _>(leaves, mmr_size, proof_iter)?;
-    println!("peaks_hashes: {:#?}", peaks_hashes);
 
+    println!();
+    println!("Calling bagging_peaks_hashes...");
     bagging_peaks_hashes::<_, M>(peaks_hashes)
 }
 

--- a/src/tests/test_accumulate_headers.rs
+++ b/src/tests/test_accumulate_headers.rs
@@ -166,28 +166,28 @@ impl Prover {
 
 #[test]
 fn test_insert_header() {
-    let mut prover = Prover::new();
-    prover.gen_blocks(30).expect("gen blocks");
-    let h1 = 11;
-    let h2 = 19;
+    // let mut prover = Prover::new();
+    // prover.gen_blocks(30).expect("gen blocks");
+    // let h1 = 11;
+    // let h2 = 19;
 
-    // get headers from prover
-    let prove_elem = {
-        let (header, td) = prover.get_header(h1);
-        HashWithTD {
-            hash: header.hash(),
-            td,
-        }
-    };
-    let root = {
-        let (later_header, _later_td) = prover.get_header(h2);
-        HashWithTD::deserialize(later_header.chain_root)
-    };
-    // gen proof,  blocks are in the same chain
-    let proof = prover.gen_proof(h1, h2).expect("gen proof");
-    let pos = leaf_index_to_pos(h1);
-    assert_eq!(pos, prover.get_pos(h1));
-    assert_eq!(prove_elem, (&prover.store).get_elem(pos).unwrap().unwrap());
-    let result = proof.verify(root, vec![(pos, prove_elem)]).expect("verify");
-    assert!(result);
+    // // get headers from prover
+    // let prove_elem = {
+    //     let (header, td) = prover.get_header(h1);
+    //     HashWithTD {
+    //         hash: header.hash(),
+    //         td,
+    //     }
+    // };
+    // let root = {
+    //     let (later_header, _later_td) = prover.get_header(h2);
+    //     HashWithTD::deserialize(later_header.chain_root)
+    // };
+    // // gen proof,  blocks are in the same chain
+    // let proof = prover.gen_proof(h1, h2).expect("gen proof");
+    // let pos = leaf_index_to_pos(h1);
+    // assert_eq!(pos, prover.get_pos(h1));
+    // assert_eq!(prove_elem, (&prover.store).get_elem(pos).unwrap().unwrap());
+    // let result = proof.verify(root, vec![(pos, prove_elem)]).expect("verify");
+    // assert!(result);
 }

--- a/src/tests/test_helper.rs
+++ b/src/tests/test_helper.rs
@@ -8,75 +8,75 @@ use crate::{
 use lazy_static::lazy_static;
 use proptest::prelude::*;
 
-lazy_static! {
-    /// Positions of 0..100_000 elem
-    static ref INDEX_TO_POS: Vec<u64> = {
-        let store = MemStore::default();
-        let mut mmr = MMR::<_,MergeNumberHash,_>::new(0, &store);
-        (0u32..100_000)
-            .map(|i| mmr.push(NumberHash::from(i)).unwrap())
-            .collect()
-    };
-    /// mmr size when 0..100_000 elem
-    static ref INDEX_TO_MMR_SIZE: Vec<u64> = {
-        let store = MemStore::default();
-        let mut mmr = MMR::<_,MergeNumberHash,_>::new(0, &store);
-        (0u32..100_000)
-            .map(|i| {
-                mmr.push(NumberHash::from(i)).unwrap();
-                mmr.mmr_size()
-            })
-            .collect()
-    };
-}
+// lazy_static! {
+//     /// Positions of 0..100_000 elem
+//     static ref INDEX_TO_POS: Vec<u64> = {
+//         let store = MemStore::default();
+//         let mut mmr = MMR::<_,MergeNumberHash,_>::new(0, &store);
+//         (0u32..100_000)
+//             .map(|i| mmr.push(NumberHash::from(i)).unwrap())
+//             .collect()
+//     };
+//     /// mmr size when 0..100_000 elem
+//     static ref INDEX_TO_MMR_SIZE: Vec<u64> = {
+//         let store = MemStore::default();
+//         let mut mmr = MMR::<_,MergeNumberHash,_>::new(0, &store);
+//         (0u32..100_000)
+//             .map(|i| {
+//                 mmr.push(NumberHash::from(i)).unwrap();
+//                 mmr.mmr_size()
+//             })
+//             .collect()
+//     };
+// }
 
-#[test]
-fn test_leaf_index_to_pos() {
-    assert_eq!(leaf_index_to_pos(0), 0);
-    assert_eq!(leaf_index_to_pos(1), 1);
-    assert_eq!(leaf_index_to_pos(2), 3);
-}
+// #[test]
+// fn test_leaf_index_to_pos() {
+//     assert_eq!(leaf_index_to_pos(0), 0);
+//     assert_eq!(leaf_index_to_pos(1), 1);
+//     assert_eq!(leaf_index_to_pos(2), 3);
+// }
 
-#[test]
-fn test_leaf_index_to_mmr_size() {
-    assert_eq!(leaf_index_to_mmr_size(0), 1);
-    assert_eq!(leaf_index_to_mmr_size(1), 3);
-    assert_eq!(leaf_index_to_mmr_size(2), 4);
-}
+// #[test]
+// fn test_leaf_index_to_mmr_size() {
+//     assert_eq!(leaf_index_to_mmr_size(0), 1);
+//     assert_eq!(leaf_index_to_mmr_size(1), 3);
+//     assert_eq!(leaf_index_to_mmr_size(2), 4);
+// }
 
-#[test]
-fn test_pos_height_in_tree() {
-    assert_eq!(pos_height_in_tree(0), 0);
-    assert_eq!(pos_height_in_tree(1), 0);
-    assert_eq!(pos_height_in_tree(2), 1);
-    assert_eq!(pos_height_in_tree(3), 0);
-    assert_eq!(pos_height_in_tree(4), 0);
-    assert_eq!(pos_height_in_tree(6), 2);
-    assert_eq!(pos_height_in_tree(7), 0);
-}
+// #[test]
+// fn test_pos_height_in_tree() {
+//     assert_eq!(pos_height_in_tree(0), 0);
+//     assert_eq!(pos_height_in_tree(1), 0);
+//     assert_eq!(pos_height_in_tree(2), 1);
+//     assert_eq!(pos_height_in_tree(3), 0);
+//     assert_eq!(pos_height_in_tree(4), 0);
+//     assert_eq!(pos_height_in_tree(6), 2);
+//     assert_eq!(pos_height_in_tree(7), 0);
+// }
 
-#[test]
-fn test_get_peaks() {
-    assert_eq!(get_peaks(0), vec![0]);
-    assert_eq!(get_peaks(1), vec![0]);
-    assert_eq!(get_peaks(2), vec![0]);
-    assert_eq!(get_peaks(3), vec![2]);
-    assert_eq!(get_peaks(4), vec![2, 3]);
-    assert_eq!(get_peaks(5), vec![2, 3]);
-    assert_eq!(get_peaks(6), vec![2, 5]);
-    assert_eq!(get_peaks(7), vec![6]);
-    assert_eq!(get_peaks(19), vec![14, 17, 18]);
-}
+// #[test]
+// fn test_get_peaks() {
+//     assert_eq!(get_peaks(0), vec![0]);
+//     assert_eq!(get_peaks(1), vec![0]);
+//     assert_eq!(get_peaks(2), vec![0]);
+//     assert_eq!(get_peaks(3), vec![2]);
+//     assert_eq!(get_peaks(4), vec![2, 3]);
+//     assert_eq!(get_peaks(5), vec![2, 3]);
+//     assert_eq!(get_peaks(6), vec![2, 5]);
+//     assert_eq!(get_peaks(7), vec![6]);
+//     assert_eq!(get_peaks(19), vec![14, 17, 18]);
+// }
 
-proptest! {
-    #[test]
-    fn test_leaf_index_to_pos_randomly(index in 0..INDEX_TO_POS.len()) {
-        let pos = leaf_index_to_pos(index as u64);
-        assert_eq!(pos, INDEX_TO_POS[index]);
-    }
+// proptest! {
+//     #[test]
+//     fn test_leaf_index_to_pos_randomly(index in 0..INDEX_TO_POS.len()) {
+//         let pos = leaf_index_to_pos(index as u64);
+//         assert_eq!(pos, INDEX_TO_POS[index]);
+//     }
 
-    #[test]
-    fn test_leaf_index_to_mmr_size_randomly(index in 0..INDEX_TO_MMR_SIZE.len()) {
-        assert_eq!(leaf_index_to_mmr_size(index as u64), INDEX_TO_MMR_SIZE[index]);
-    }
-}
+//     #[test]
+//     fn test_leaf_index_to_mmr_size_randomly(index in 0..INDEX_TO_MMR_SIZE.len()) {
+//         assert_eq!(leaf_index_to_mmr_size(index as u64), INDEX_TO_MMR_SIZE[index]);
+//     }
+// }

--- a/src/tests/test_mmr.rs
+++ b/src/tests/test_mmr.rs
@@ -32,135 +32,135 @@ fn test_mmr(count: u32, proof_elem: Vec<u32>) {
     assert!(result);
 }
 
-fn test_gen_new_root_from_proof(count: u32) {
-    let store = MemStore::default();
-    let mut mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
-    let positions: Vec<u64> = (0u32..count)
-        .map(|i| mmr.push(NumberHash::from(i)).unwrap())
-        .collect();
-    let elem = count - 1;
-    let pos = positions[elem as usize];
-    let proof = mmr.gen_proof(vec![pos]).expect("gen proof");
-    let new_elem = count;
-    let new_pos = mmr.push(NumberHash::from(new_elem)).unwrap();
-    let root = mmr.get_root().expect("get root");
-    mmr.commit().expect("commit changes");
-    let calculated_root = proof
-        .calculate_root_with_new_leaf(
-            vec![(pos, NumberHash::from(elem))],
-            new_pos,
-            NumberHash::from(new_elem),
-            leaf_index_to_mmr_size(new_elem.into()),
-        )
-        .unwrap();
-    assert_eq!(calculated_root, root);
-}
+// fn test_gen_new_root_from_proof(count: u32) {
+//     let store = MemStore::default();
+//     let mut mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
+//     let positions: Vec<u64> = (0u32..count)
+//         .map(|i| mmr.push(NumberHash::from(i)).unwrap())
+//         .collect();
+//     let elem = count - 1;
+//     let pos = positions[elem as usize];
+//     let proof = mmr.gen_proof(vec![pos]).expect("gen proof");
+//     let new_elem = count;
+//     let new_pos = mmr.push(NumberHash::from(new_elem)).unwrap();
+//     let root = mmr.get_root().expect("get root");
+//     mmr.commit().expect("commit changes");
+//     let calculated_root = proof
+//         .calculate_root_with_new_leaf(
+//             vec![(pos, NumberHash::from(elem))],
+//             new_pos,
+//             NumberHash::from(new_elem),
+//             leaf_index_to_mmr_size(new_elem.into()),
+//         )
+//         .unwrap();
+//     assert_eq!(calculated_root, root);
+// }
 
-#[test]
-fn test_mmr_root() {
-    let store = MemStore::default();
-    let mut mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
-    (0u32..11).for_each(|i| {
-        mmr.push(NumberHash::from(i)).unwrap();
-    });
-    let root = mmr.get_root().expect("get root");
-    let hex_root = hex_string(&root.0).unwrap();
-    assert_eq!(
-        "f6794677f37a57df6a5ec36ce61036e43a36c1a009d05c81c9aa685dde1fd6e3",
-        hex_root
-    );
-}
+// #[test]
+// fn test_mmr_root() {
+//     let store = MemStore::default();
+//     let mut mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
+//     (0u32..11).for_each(|i| {
+//         mmr.push(NumberHash::from(i)).unwrap();
+//     });
+//     let root = mmr.get_root().expect("get root");
+//     let hex_root = hex_string(&root.0).unwrap();
+//     assert_eq!(
+//         "f6794677f37a57df6a5ec36ce61036e43a36c1a009d05c81c9aa685dde1fd6e3",
+//         hex_root
+//     );
+// }
 
-#[test]
-fn test_empty_mmr_root() {
-    let store = MemStore::<NumberHash>::default();
-    let mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
-    assert_eq!(Err(Error::GetRootOnEmpty), mmr.get_root());
-}
+// #[test]
+// fn test_empty_mmr_root() {
+//     let store = MemStore::<NumberHash>::default();
+//     let mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
+//     assert_eq!(Err(Error::GetRootOnEmpty), mmr.get_root());
+// }
 
-#[test]
-fn test_mmr_3_peaks() {
-    test_mmr(11, vec![5]);
-}
+// #[test]
+// fn test_mmr_3_peaks() {
+//     test_mmr(11, vec![5]);
+// }
 
-#[test]
-fn test_mmr_2_peaks() {
-    test_mmr(10, vec![5]);
-}
+// #[test]
+// fn test_mmr_2_peaks() {
+//     test_mmr(10, vec![5]);
+// }
 
-#[test]
-fn test_mmr_1_peak() {
-    test_mmr(8, vec![5]);
-}
+// #[test]
+// fn test_mmr_1_peak() {
+//     test_mmr(8, vec![5]);
+// }
 
-#[test]
-fn test_mmr_first_elem_proof() {
-    test_mmr(11, vec![0]);
-}
+// #[test]
+// fn test_mmr_first_elem_proof() {
+//     test_mmr(11, vec![0]);
+// }
 
-#[test]
-fn test_mmr_last_elem_proof() {
-    test_mmr(11, vec![10]);
-}
+// #[test]
+// fn test_mmr_last_elem_proof() {
+//     test_mmr(11, vec![10]);
+// }
 
-#[test]
-fn test_mmr_1_elem() {
-    test_mmr(1, vec![0]);
-}
+// #[test]
+// fn test_mmr_1_elem() {
+//     test_mmr(1, vec![0]);
+// }
 
-#[test]
-fn test_mmr_2_elems() {
-    test_mmr(2, vec![0]);
-    test_mmr(2, vec![1]);
-}
+// #[test]
+// fn test_mmr_2_elems() {
+//     test_mmr(2, vec![0]);
+//     test_mmr(2, vec![1]);
+// }
 
-#[test]
-fn test_mmr_2_leaves_merkle_proof() {
-    test_mmr(11, vec![3, 7]);
-    test_mmr(11, vec![3, 4]);
-}
+// #[test]
+// fn test_mmr_2_leaves_merkle_proof() {
+//     test_mmr(11, vec![3, 7]);
+//     test_mmr(11, vec![3, 4]);
+// }
 
-#[test]
-fn test_mmr_2_sibling_leaves_merkle_proof() {
-    test_mmr(11, vec![4, 5]);
-    test_mmr(11, vec![5, 6]);
-    test_mmr(11, vec![6, 7]);
-}
+// #[test]
+// fn test_mmr_2_sibling_leaves_merkle_proof() {
+//     test_mmr(11, vec![4, 5]);
+//     test_mmr(11, vec![5, 6]);
+//     test_mmr(11, vec![6, 7]);
+// }
 
 #[test]
 fn test_mmr_3_leaves_merkle_proof() {
     test_mmr(11, vec![4, 5, 6]);
-    test_mmr(11, vec![3, 5, 7]);
-    test_mmr(11, vec![3, 4, 5]);
-    test_mmr(100, vec![3, 5, 13]);
+    // test_mmr(11, vec![3, 5, 7]);
+    // test_mmr(11, vec![3, 4, 5]);
+    // test_mmr(100, vec![3, 5, 13]);
 }
 
-#[test]
-fn test_gen_root_from_proof() {
-    test_gen_new_root_from_proof(11);
-}
+// #[test]
+// fn test_gen_root_from_proof() {
+//     test_gen_new_root_from_proof(11);
+// }
 
-prop_compose! {
-    fn count_elem(count: u32)
-                (elem in 0..count)
-                -> (u32, u32) {
-                    (count, elem)
-    }
-}
+// prop_compose! {
+//     fn count_elem(count: u32)
+//                 (elem in 0..count)
+//                 -> (u32, u32) {
+//                     (count, elem)
+//     }
+// }
 
-proptest! {
-    #[test]
-    fn test_random_mmr(count in 10u32..500u32) {
-        let mut leaves: Vec<u32> = (0..count).collect();
-        let mut rng = thread_rng();
-        leaves.shuffle(&mut rng);
-        let leaves_count = rng.gen_range(1, count - 1);
-        leaves.truncate(leaves_count as usize);
-        test_mmr(count, leaves);
-    }
+// proptest! {
+//     #[test]
+//     fn test_random_mmr(count in 10u32..500u32) {
+//         let mut leaves: Vec<u32> = (0..count).collect();
+//         let mut rng = thread_rng();
+//         leaves.shuffle(&mut rng);
+//         let leaves_count = rng.gen_range(1, count - 1);
+//         leaves.truncate(leaves_count as usize);
+//         test_mmr(count, leaves);
+//     }
 
-    #[test]
-    fn test_random_gen_root_with_new_leaf(count in 1u32..500u32) {
-        test_gen_new_root_from_proof(count);
-    }
-}
+//     #[test]
+//     fn test_random_gen_root_with_new_leaf(count in 1u32..500u32) {
+//         test_gen_new_root_from_proof(count);
+//     }
+// }

--- a/src/tests/test_mmr.rs
+++ b/src/tests/test_mmr.rs
@@ -3,6 +3,7 @@ use crate::{leaf_index_to_mmr_size, util::MemStore, Error, MMR};
 use faster_hex::hex_string;
 use proptest::prelude::*;
 use rand::{seq::SliceRandom, thread_rng};
+use bytes::Bytes;
 
 fn test_mmr(count: u32, proof_elem: Vec<u32>) {
     let store = MemStore::default();
@@ -20,6 +21,7 @@ fn test_mmr(count: u32, proof_elem: Vec<u32>) {
         )
         .expect("gen proof");
     mmr.commit().expect("commit changes");
+
     let result = proof
         .verify(
             root,
@@ -90,13 +92,74 @@ fn test_mmr(count: u32, proof_elem: Vec<u32>) {
 
 // #[test]
 // fn test_mmr_1_peak() {
-//     test_mmr(8, vec![5]);
+//     test_mmr(7, vec![5]);
 // }
 
 // #[test]
 // fn test_mmr_first_elem_proof() {
 //     test_mmr(11, vec![0]);
 // }
+
+#[test]
+fn test_calculate_peak_root() {
+
+    println!("----------- test_calculate_peak_root -----------");
+    let store = MemStore::default();
+    let mut mmr = MMR::<_, MergeNumberHash, _>::new(0, &store);
+
+    // Push leaves 0-6 to the MMR as number hashes
+    println!("Appending leaves [0-6]");
+    let numLeaves = 7;
+    let positions: Vec<u64> = (0u32..numLeaves)
+    .map(|i| mmr.push(NumberHash::from(i)).unwrap())
+    .collect();
+
+    // Input integers 0-6 are hashed into the following leaves:
+    // let leafHashes = [
+    //     "0xc3e7ba6b511162fead58f2c8b5764ce869ed1118011ac37392522ed16720bbcd",
+    //     "0x037ff5a3903a59630e03b84cda912c26bf19442efe2cd30c2a25547e06ded385",
+    //     "0xffb0ad2811094c7f63826e33b6d7b3afa72587be856a86f10e3d0d869bbc37e5",
+    //     "0xf47e991c124932a8573f782e1bc2fa62f628f8e1e074e6193170b0e302e37421",
+    //     "0xd2ad83af7d5b0387eb704e57f4539138df402d72704fb74fde7a33353fab598d",
+    //     "0xe232c7350837c9d87a948ddfc4286cc49d946e8cdad9121e91595f190ed7e54d",
+    //     "0x32d44b4a8e8a3046b9c02315847eb091678a59f136226e70d66f3a82bd836ce1"
+    // ];
+
+    // Get the actual root and log
+    let root = mmr.get_root().expect("get root");
+    println!("root: {:?}", root);
+
+    // We want the proof for index 5
+    let proof_elem = [2, 5, 6];
+
+    // Calculate leaf data (it's just [2, 5, 6])
+    let leaf_data = proof_elem
+        .iter()
+        .map(|elem| positions[*elem as usize])
+        .collect();
+
+    // Generate the proof and commit it to the MMR
+    let proof = mmr
+        .gen_proof(
+            leaf_data,
+        )
+        .expect("gen proof");
+    mmr.commit().expect("commit changes");
+
+    // Calculate the proof element hashes using NumberHash helper
+    let leaf_hashes = proof_elem
+        .iter()
+        .map(|elem| (positions[*elem as usize], NumberHash::from(*elem)))
+        .collect();
+
+    // Calculate the root and log
+    // 1. calculate_root calls
+    // 1a. calculate_peaks_hashes -> returns bagged peaks [0123, 45, 6]
+    // 1b. bagging_peaks_hashes -> [6, 45] -> [645, 0123] -> [0123456] = root
+    let calculatedRoot = proof.calculate_root(leaf_hashes);
+    println!();
+    println!("calculatedRoot: {:?}", calculatedRoot);
+}
 
 // #[test]
 // fn test_mmr_last_elem_proof() {
@@ -127,13 +190,13 @@ fn test_mmr(count: u32, proof_elem: Vec<u32>) {
 //     test_mmr(11, vec![6, 7]);
 // }
 
-#[test]
-fn test_mmr_3_leaves_merkle_proof() {
-    test_mmr(11, vec![4, 5, 6]);
-    // test_mmr(11, vec![3, 5, 7]);
-    // test_mmr(11, vec![3, 4, 5]);
-    // test_mmr(100, vec![3, 5, 13]);
-}
+// #[test]
+// fn test_mmr_3_leaves_merkle_proof() {
+//     // test_mmr(11, vec![4, 5, 6]);
+//     // test_mmr(11, vec![3, 5, 7]);
+//     // test_mmr(11, vec![3, 4, 5]);
+//     // test_mmr(100, vec![3, 5, 13]);
+// }
 
 // #[test]
 // fn test_gen_root_from_proof() {


### PR DESCRIPTION
Running with `cargo test -- --nocapture` gives output:
```
running 2 tests

root: NumberHash(b"\xf6yFw\xf3zW\xdfj^\xc3l\xe6\x106\xe4:6\xc1\xa0\t\xd0\\\x81\xc9\xaah]\xde\x1f\xd6\xe3")
leaves len: 3
leaves: [(7, NumberHash(b"&\xa0\x8eM\x0cQ\x90\xf0\x18q\xe0V\x9bb\x90\xb8g`\x08]\x99\xf1~\xb4\xe7\xe6\xb5\x8f\xeb\x8dbI")), (8, NumberHash(b"\x8c5\xd2/E\x9dw\xcaL\x0b\x0bP5\x86\x97f\xd6\r\x18+\x97\x16\xab>\x88y\xe0fG\x88\x99\xa8")), (10, NumberHash(b"\xf4\xaa\xc2\xfb\xe3?\x03UK\xfe\xb5Y\xea&\x90\xed\x85!\xca\xa4\xbe\x96\x1ea\xc9\x1a\xc9\xa1S\r\xcez"))]

mmr_size: 19
peaks_hashes: [
    NumberHash(
        b"\x9aB\xe0\xef\xd1B\xd8\xda\xdb#\xfe^\xecKPx\xc9\xect\r\x99'\x10\x96F\xbc\xad\x1c\x999\xbe\x80",
    ),
    NumberHash(
        b"^{\xc6c#\xe3L\xcb\xbe\x88\xba\x91r\xc6\xda\xdb\xb0P\xf0\xfb`\xa0Kv\x1e\x95\xabFX\r\xdc^",
    ),
]
test tests::test_mmr::test_mmr_3_leaves_merkle_proof ... ok

root: HashWithTD { hash: 995e0612a6269683900999100b5a04fdd91120558aeca8ca97811e1199e590a1, td: 171 }
leaves len: 1
leaves: [(19, HashWithTD { hash: 40500594b18877c9d1f3114cf0ef0b6eade35b63671b534f7a974ac9f907a03c, td: 11 })]

mmr_size: 35
peaks_hashes: [
    HashWithTD { hash: a75c04c4474c8b018cb3861e14e571649554c1cbc76b81b14d23cc2a2ddac7cb, td: 120 },
    HashWithTD { hash: bca3d45e6fa547f7badec0019148bee59c93554a099f754c6c198f052e75b2c9, td: 51 },
]
test tests::test_accumulate_headers::test_insert_header ... ok
```